### PR TITLE
chore(deps): upgrade better-sqlite3 from 9.2.2 to 12.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.1.5",
     "@tootallnate/once": "^3.0.1",
     "@types/node": "^24.0.13",
-    "better-sqlite3": "^9.2.2",
+    "better-sqlite3": "^12.10.0",
     "brace-expansion": "^5.0.6",
     "tar": "^7.5.13",
     "tsx": "^4.20.3",


### PR DESCRIPTION
## Summary
Upgrade `better-sqlite3` from `9.2.2` to `12.10.0`.

**Reason:** outdated

**Tests:** All tests pass locally.

_This PR was opened by a bot._