### PR TITLE
chore(deps): upgrade ts-jest from 29.4.9 to 29.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/better-sqlite3": "^7.6.8",
         "@types/jest": "^30.0.0",
         "jest": "^30.3.0",
-        "ts-jest": "^29.4.9"
+        "ts-jest": "^29.4.11"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/better-sqlite3": "^7.6.8",
     "@types/jest": "^30.0.0",
     "jest": "^30.3.0",
-    "ts-jest": "^29.4.9"
+    "ts-jest": "^29.4.11"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Upgrades ts-jest from 29.4.9 to 29.4.11. Bug fixes in 29.4.10 and 29.4.11.

Tests: same pre-existing failures (3 test suites with type errors, unrelated to ts-jest).