### PR TITLE
chore(deps): upgrade tsx from 4.22.3 to 4.22.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "better-sqlite3": "^12.10.0",
     "brace-expansion": "^5.0.6",
     "tar": "^7.5.13",
-    "tsx": "^4.22.3",
+    "tsx": "^4.22.4",
     "typescript": "^5.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Upgrade `tsx` from `4.22.3` to `4.22.4`.

**Reason:** outdated

**Tests:** Pre-existing test failures unrelated to this upgrade (TypeScript type errors in test files)

_This PR was opened by a bot._