### PR TITLE
chore(deps): upgrade @types/node from 24.0.13 to 24.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@tootallnate/once": "^3.0.1",
-        "@types/node": "^24.0.13",
+        "@types/node": "^24.13.2",
         "better-sqlite3": "^12.10.0",
         "brace-expansion": "^5.0.6",
         "tar": "^7.5.13",
@@ -1913,12 +1913,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -5572,9 +5572,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.5",
     "@tootallnate/once": "^3.0.1",
-    "@types/node": "^24.0.13",
+    "@types/node": "^24.13.2",
     "better-sqlite3": "^12.10.0",
     "brace-expansion": "^5.0.6",
     "tar": "^7.5.13",


### PR DESCRIPTION
## Summary
Upgrade `@types/node` from `24.0.13` to `24.13.2`.

**Reason:** outdated

**Tests:** Pre-existing test failures unrelated to this upgrade (TypeScript type errors in test files)

_This PR was opened by a bot._