### PR TITLE
chore(deps): upgrade brace-expansion from 5.0.6 to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tootallnate/once": "^3.0.1",
     "@types/node": "^24.0.13",
     "better-sqlite3": "^12.10.0",
-    "brace-expansion": "^5.0.6",
+    "brace-expansion": "^5.1.0",
     "tar": "^7.5.13",
     "tsx": "^4.22.3",
     "typescript": "^5.8.3"


### PR DESCRIPTION
## Summary
Upgrade `brace-expansion` from `5.0.6` to `5.1.0`.

**Reason:** outdated

_This PR was opened by a bot._