### PR TITLE
fix(deps): upgrade tar from 7.5.13 to 7.5.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/node": "^24.0.13",
         "better-sqlite3": "^12.10.0",
         "brace-expansion": "^5.0.6",
-        "tar": "^7.5.13",
+        "tar": "^7.5.16",
         "tsx": "^4.22.3",
         "typescript": "^5.8.3"
       },
@@ -5271,9 +5271,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^24.0.13",
     "better-sqlite3": "^12.10.0",
     "brace-expansion": "^5.0.6",
-    "tar": "^7.5.13",
+    "tar": "^7.5.16",
     "tsx": "^4.22.3",
     "typescript": "^5.8.3"
   },


### PR DESCRIPTION
## Summary
Upgrades tar from 7.5.13 to 7.5.16 to fix CVE-2024-21538.

## Changes
- Bump tar from ^7.5.13 to ^7.5.16 in package.json
- Update package-lock.json

## Security Fix
This upgrade addresses CVE-2024-21538: tar parser interpretation differential (file smuggling) via PAX size override.

## Testing
- Tests pass (3 failed suites, 9 passing - same as baseline with pre-existing failures)